### PR TITLE
Add missing parameters to plugin proceed method

### DIFF
--- a/src/ViewModel/ProductList/Plugin.php
+++ b/src/ViewModel/ProductList/Plugin.php
@@ -68,7 +68,7 @@ class Plugin extends AbstractRecommendationPlugin
         $this->type = Config::RECCOMENDATION_TYPE_SHOPPINGCART;
 
         if (!$this->config->isRecommendationsEnabled($this->getType())) {
-            return $proceed();
+            return $proceed(...$cartItems);
         }
 
         // return most recently added product crosssell items first


### PR DESCRIPTION
We need to add arguments to proceed when using around plugin
return $proceed(...$cartItems); otherwise the items in checkout cart will be empty 