### PR TITLE
Fix product item blocks/forms being cached without a form_key

### DIFF
--- a/src/view/frontend/layout/hyva_tweakwise_ajax_category.xml
+++ b/src/view/frontend/layout/hyva_tweakwise_ajax_category.xml
@@ -16,6 +16,7 @@
     </container>
     <update handle="hyva_catalog_category_view_type_layered"/>
     <update handle="hyva_catalog_category_view"/>
+    <block class="Magento\Framework\View\Element\FormKey" name="formkey"/>
     <!-- Remove featured products from content as it would be rendered again in ajax call which is not needed -->
     <referenceBlock name="tweakwise.catalog.product.featured.before" remove="true"/>
 </layout>

--- a/src/view/frontend/layout/hyva_tweakwise_ajax_search.xml
+++ b/src/view/frontend/layout/hyva_tweakwise_ajax_search.xml
@@ -15,4 +15,5 @@
         <container name="sidebar.main"/>
     </container>
     <update handle="hyva_catalogsearch_result_index"/>
+    <block class="Magento\Framework\View\Element\FormKey" name="formkey"/>
 </layout>

--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -308,20 +308,6 @@ use Magento\Framework\View\Element\Template;
                 and we dont want to replace them all
                 */
                 if (newProductList && toolbars.length) {
-                    const forms = newProductList.querySelectorAll('form');
-                    const formKey = hyva.getFormKey();
-
-                    if (forms && formKey) {
-                        Array.from(forms).forEach((form) => {
-                            const formKeyInput = document.createElement('input');
-                            formKeyInput.type = 'hidden';
-                            formKeyInput.name = 'form_key';
-                            formKeyInput.value = formKey;
-
-                            form.appendChild(formKeyInput);
-                        });
-                    }
-
                     const oldProductList = this.getNextSibling(toolbars[0], productListSelector)
                     this.replaceNode(oldProductList, newProductList)
                 }


### PR DESCRIPTION
We ran into an issue where product blocks were cached without a form_key after filtering (ajax).

When filtering (ajax), different products are loaded onto the page without form keys, but you can still add the products to the cart because in navigation-form.phtml the form key is added to each item with javascript. However, this code is not executed in all scenarios, for example after manually refreshing the page after your ajax filter action. If the block was not cached before, it now seems to be cached without a form key. And then you can't add the product to cart from the PLP, as Magento will throw a "Your session has expired" error.