### PR TITLE
Update form keys after products have been added to page (ajaxUpdate).

### DIFF
--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -309,7 +309,8 @@ use Magento\Framework\View\Element\Template;
                 */
                 if (newProductList && toolbars.length) {
                     const oldProductList = this.getNextSibling(toolbars[0], productListSelector)
-                    this.replaceNode(oldProductList, newProductList)
+                    this.replaceNode(oldProductList, newProductList);
+                    hyva.initFormKey();
                 }
 
                 if (newToolbarFirst && toolbars) {


### PR DESCRIPTION
Actually a follow-up of #20, in which I removed certain logic to add form keys to the product items. That logic should not have been removed completely, because now form keys _can_ be incorrect after ajax filtering. However, in that PR the form_keys are added via layout xml (to solve items being cached without a form key), so now we can simply use the Hyvä method initFormKey() to update all form keys on the page (including those of products loaded via ajax and just added to the page).