### PR TITLE
Fix sort filter items not working and fix incorrect sort order

### DIFF
--- a/src/view/frontend/templates/layer/view.phtml
+++ b/src/view/frontend/templates/layer/view.phtml
@@ -175,7 +175,7 @@ $filtered = count($block->getLayer()->getState()->getFilters());
             return {
                 moreItemsShow: false,
                 sortItems(hasAlternateSort) {
-                    if (!hasAlternateSort || this.$refs.items || this.$refs.items.children) {
+                    if (!hasAlternateSort || !this.$refs.items || !this.$refs.items.children) {
                         return
                     }
 

--- a/src/view/frontend/templates/layer/view.phtml
+++ b/src/view/frontend/templates/layer/view.phtml
@@ -182,7 +182,8 @@ $filtered = count($block->getLayer()->getState()->getFilters());
                     const items = this.$refs.items
                     const sortType = this.moreItemsShow ? 'alternateSort' : 'originalSort'
 
-                    Array.from(items.children).sort((a, b) => a.dataset[sortType].localeCompare(b.dataset[sortType]))
+                    Array.from(items.children)
+                        .sort((a, b) => a.dataset[sortType].localeCompare(b.dataset[sortType],undefined,{numeric: true}))
                         .forEach((item) => {
                             items.appendChild(item);
                         });


### PR DESCRIPTION
The logic for smart filters / alternative sorting is already there, but because of the incorrect if-statement the items are never sorted. This mini PR fixes this.

This PR also fixes an issue where items aren't sorted correctly, because by default, using localeCompare, "2" > "10". Resulting in items being sorted as: "1, 10, 11, 12, 13, 2, 4, 5" etc. By setting the numeric option, items are ordered correctly: "1, 2, 3, 4, [...], 9, 10, 11, 12" etc.