### PR TITLE
Add page nr to reload

### DIFF
--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -79,6 +79,17 @@ use Magento\Framework\View\Element\Template;
              */
             pmListReload(cookieName) {
                 if (hyva.getCookie(cookieName) !== null) {
+                    const urlParams = new URLSearchParams(window.location.search);
+
+                    if (urlParams.get('p')) {
+                        const filterForm = document.querySelector(this.filterFormSelector);
+                        var pageParam = document.createElement('input');
+                        pageParam.setAttribute('type','hidden');
+                        pageParam.setAttribute('name','p');
+                        pageParam.value = parseInt(urlParams.get('p'));
+
+                        filterForm.querySelector('.filter-options').appendChild(newField);
+                    }
                     const changeEvent = new Event('change');
                     this.$root.dispatchEvent(changeEvent);
                 }


### PR DESCRIPTION
When using personal merchandising the page nr gets lost on page reload. This pull requests fixes that, and adds the page nr to the ajax request reloading the page.