### PR TITLE
make ALP overview page hyva compatible

### DIFF
--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -16,6 +16,10 @@
                     <item name="original_module" xsi:type="string">Tweakwise_Magento2Tweakwise</item>
                     <item name="compat_module" xsi:type="string">Tweakwise_TweakwiseHyva</item>
                 </item>
+                <item name="hyva-emico_attributeLanding" xsi:type="array">
+                    <item name="original_module" xsi:type="string">Emico_AttributeLanding</item>
+                    <item name="compat_module" xsi:type="string">Tweakwise_TweakwiseHyva</item>
+                </item>
             </argument>
         </arguments>
     </type>

--- a/src/view/frontend/templates/overview-page/view.phtml
+++ b/src/view/frontend/templates/overview-page/view.phtml
@@ -1,0 +1,14 @@
+<?php
+/** @var \Emico\AttributeLanding\Block\OverviewPage\View $this */
+?>
+<div><?=$this->getContentFirst()?></div>
+<div class="landingpages-grid grid sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
+    <?php foreach ($this->getLandingPages() as $landingPage): ?>
+        <div class="m-2">
+            <a href="<?=$landingPage->getUrlPath()?>"><?=$landingPage->getHeading() ?: $landingPage->getName()?>
+                <img src="<?=$this->getLandingPageImage($landingPage)?>" />
+            </a>
+        </div>
+    <?php endforeach; ?>
+</div>
+<div><?=$this->getContentLast()?></div>


### PR DESCRIPTION
The overviewpage from the ALP module is not Hyva compatible. This pull requests adds hyva styles to the ALP overviewpage