### PR TITLE
Fix category url

### DIFF
--- a/src/view/frontend/templates/product/layered/tree/item.phtml
+++ b/src/view/frontend/templates/product/layered/tree/item.phtml
@@ -18,7 +18,7 @@ $item = $block->getItem();
 
 ?>
 <li class="item">
-    <a href="<?= $escaper->escapeUrl($item->getUrl()) ?>" class="flex w-full py-1 mb-1 hover:text-black">
+    <a href="<?= $escaper->escapeUrl($block->getCategoryUrl($item)) ?>" class="flex w-full py-1 mb-1 hover:text-black">
         <?= $block->getItemPrefix() ?>
         <?= $escaper->escapeHtml($item->getLabel()) ?>
         <?= $block->getItemPostfix() ?>


### PR DESCRIPTION
When the cateogry view in Tweakwise is set to tree, the category url's in the hyva theme are not correct. The urls contain the current category url for other categories. For example the url for the category men, when the womens category is selected is https://shop.url/women/men instead of https://shop.url/men

This pull request fixes that

