### PR TITLE
feat: searchable filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "hyva-themes/magento2-compat-module-fallback": "*",
         "hyva-themes/magento2-default-theme": "^1.2",
         "php": ">=8.0 <8.3",
-        "tweakwise/magento2-tweakwise": ">=5.2.0."
+        "tweakwise/magento2-tweakwise": ">=6.0.0."
     },
     "autoload": {
         "files": [

--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -323,6 +323,7 @@ use Magento\Framework\View\Element\Template;
                     this.replaceNode(oldToolbarLast, newToolbarLast);
                 }
             },
+
             ajaxUpdateState(response) {
                 window.history.pushState({html: response.html}, '', response.url);
             },

--- a/src/view/frontend/templates/layer/view.phtml
+++ b/src/view/frontend/templates/layer/view.phtml
@@ -193,6 +193,55 @@ $filtered = count($block->getLayer()->getState()->getFilters());
                 }
             }
         }
+
+        function initFilterSearch() {
+            return {
+                filterSearch() {
+                    let items = this.$refs.items;
+                    const filterSearch = this.$refs.tw_filtersearch;
+                    let value = filterSearch.value.toLowerCase().trim();
+                    let noItems = this.$refs.search_no_results;
+                    let moreItems = this.$refs.moreItems;
+                    let lessItems = this.$refs.lessItems;
+
+                    //swatch
+                    if (!items || !items.children) {
+                        items = this.$refs.swatch;
+                    }
+
+                    if (!items || !items.children) {
+                        return;
+                    }
+
+                    Array.from(items.children).forEach(function(item) {
+                        //find input element in item
+                        let input = item.querySelector('input');
+                        if (input.value.toLowerCase().trim().indexOf(value) === -1) {
+                            item.style.display = 'none';
+                        } else {
+                            item.style.display = '';
+                        }
+                    });
+
+                    let visibleItems = Array.from(items.children).filter(item => item.style.display !== 'none');
+                    if(visibleItems.length < 1) {
+                        noItems.style.display = '';
+                    } else {
+                        noItems.style.display = 'none';
+                    }
+
+                    if (moreItems) {
+                        if(value.length === 0) {
+                            moreItems.style.display = '';
+                            lessItems.style.display = '';
+                        } else {
+                            moreItems.style.display = 'none';
+                            lessItems.style.display = 'none';
+                        }
+                    }
+                }
+            }
+        }
     </script>
 
 <?=$block->getChildHtml('tweakwise.navigation.form');?>

--- a/src/view/frontend/templates/product/layered/default.phtml
+++ b/src/view/frontend/templates/product/layered/default.phtml
@@ -16,8 +16,13 @@ use Tweakwise\Magento2Tweakwise\Block\LayeredNavigation\RenderLayered\DefaultRen
 
 $hasHiddenItems = $block->hasHiddenItems();
 $hasAlternateSortOrder = $block->hasAlternateSortOrder();
+
 ?>
 <div x-data="initTweakwiseNavigationItems()" x-init='sortItems(<?= (int)$hasAlternateSortOrder ?>)'>
+    <?php if ($block->isSearchable()): ?>
+        <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
+        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+    <?php endif; ?>
     <ol class="items" x-ref="items">
         <?php foreach ($block->getItems() as $index => $item): ?>
             <li class="item"

--- a/src/view/frontend/templates/product/layered/default.phtml
+++ b/src/view/frontend/templates/product/layered/default.phtml
@@ -20,8 +20,8 @@ $hasAlternateSortOrder = $block->hasAlternateSortOrder();
 ?>
 <div x-data="initTweakwiseNavigationItems()" x-init='sortItems(<?= (int)$hasAlternateSortOrder ?>)'>
     <?php if ($block->isSearchable()): ?>
-        <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
-        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+        <input @keyUp="filterSearch()" x-ref="tw_filtersearch" x-data="initFilterSearch()" data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
+        <div x-ref="search_no_results" style="display: none" class="search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
     <?php endif; ?>
     <ol class="items" x-ref="items">
         <?php foreach ($block->getItems() as $index => $item): ?>
@@ -29,6 +29,7 @@ $hasAlternateSortOrder = $block->hasAlternateSortOrder();
                 :class="{ 'block': moreItemsShow, 'hidden': '<?=$block->itemDefaultHidden($item)?>' && !moreItemsShow }"
                 <?php if ($hasAlternateSortOrder): ?>
                     data-alternate-sort="<?= $item->getAlternateSortOrder(); ?>"
+
                     data-original-sort="<?= $index; ?>"
                 <?php endif; ?>
             >
@@ -71,11 +72,13 @@ $hasAlternateSortOrder = $block->hasAlternateSortOrder();
         <a href="#" class="more-items underline cursor-pointer"
            @click.prevent="toggleShowMore(true, <?= (int)$hasAlternateSortOrder ?>)"
            :class="{ 'hidden': moreItemsShow }"
+           x-ref="moreItems"
         ><?= __($block->getMoreItemText()) ?></a>
         <a href="#" class="less-items underline cursor-pointer"
            x-cloak
            @click.prevent="toggleShowMore(false, <?= (int)$hasAlternateSortOrder ?>)"
            :class="{ 'block': moreItemsShow, 'hidden': !moreItemsShow }"
+           x-ref="lessItems"
         ><?= __($block->getLessItemText()) ?></a>
     <?php endif; ?>
 </div>

--- a/src/view/frontend/templates/product/layered/swatch.phtml
+++ b/src/view/frontend/templates/product/layered/swatch.phtml
@@ -89,6 +89,10 @@ if (!$swatchData['swatches']) {
      x-data="initLayeredSwatch_<?= $escaper->escapeJs($swatchData['attribute_code']) ?>()"
      data-attribute-code="<?= $escaper->escapeHtmlAttr($swatchData['attribute_code']) ?>"
      data-attribute-id="<?= $escaper->escapeHtmlAttr($swatchData['attribute_id']) ?>">
+    <?php if ($block->isSearchable()): ?>
+        <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
+        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+    <?php endif; ?>
     <div class="swatch-attribute-options clearfix flex flex-row flex-wrap">
         <?php foreach ($swatchData['options'] as $option => $label): ?>
             <?php

--- a/src/view/frontend/templates/product/layered/swatch.phtml
+++ b/src/view/frontend/templates/product/layered/swatch.phtml
@@ -90,10 +90,10 @@ if (!$swatchData['swatches']) {
      data-attribute-code="<?= $escaper->escapeHtmlAttr($swatchData['attribute_code']) ?>"
      data-attribute-id="<?= $escaper->escapeHtmlAttr($swatchData['attribute_id']) ?>">
     <?php if ($block->isSearchable()): ?>
-        <input data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
-        <div style="display: none" class="tw_search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
+        <input @keyUp="filterSearch()" x-ref="tw_filtersearch" x-data="initFilterSearch()" data-max-visible="<?=  $block->getMaxItemsShown()?>" type="text" class="tw_filtersearch js-skip-submit" name="tw_filtersearch" placeholder="<?= $block->getSearchPlaceholder(); ?>" >
+        <div x-ref="search_no_results" style="display: none" class="search_no_results empty"><?= $block->getSearchNoResultsText(); ?></div>
     <?php endif; ?>
-    <div class="swatch-attribute-options clearfix flex flex-row flex-wrap">
+    <div class="swatch-attribute-options clearfix flex flex-row flex-wrap" x-ref="swatch">
         <?php foreach ($swatchData['options'] as $option => $label): ?>
             <?php
             $item = $block->getItemForSwatch($option);


### PR DESCRIPTION
When the filtersearch option is enabled within Tweakwise for a specific filter in the filter template, a search box will now appear above the filter. This search box allows users to conveniently search through the filter values associated with that particular filter.

In cases where no filters are found, the designated text for displaying no results as configured in Tweakwise will be shown.

Additionally, users have the option to specify placeholder text for the search box within Tweakwise.

These modifications have been implemented within the default filter view. If you have customized your own view, please ensure to incorporate these changes accordingly.

This pull request requires https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/166 to be released. If that is released, the composer requirements need to be updated to ensure the latest version of the tweakwise module is used.