### PR TITLE
fix: bump php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "magento/framework": "*",
         "hyva-themes/magento2-compat-module-fallback": "*",
         "hyva-themes/magento2-default-theme": "^1.2",
-        "php": "^8.0",
+        "php": "^8.1",
         "tweakwise/magento2-tweakwise": ">=8.0.0."
     },
     "autoload": {


### PR DESCRIPTION
Bump minimum php version to 8.1. Php 8.1 is needed since the recommendation changes, but it wasn't updated in the composer.json.