### PR TITLE
fix: Uncaught TypeError: invalid assignment to const href

### DIFF
--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -143,7 +143,7 @@ use Magento\Framework\View\Element\Template;
              * Should return the url to navigate to
              */
             findHref(aElement) {
-                const href = aElement.getAttribute('href');
+                let href = aElement.getAttribute('href');
                 if (this.seoEnabled) {
                     const seoHref = aElement.dataset.seoHref;
                     href = seoHref ? seoHref : href;


### PR DESCRIPTION
Line 149 results in `Uncaught TypeError: invalid assignment to const 'href'` when clicking on a layerednav option.