### PR TITLE
fix: Show visuals without merchandising builder and AJAX filtering enabled

### DIFF
--- a/src/view/frontend/layout/hyva_catalog_category_view.xml
+++ b/src/view/frontend/layout/hyva_catalog_category_view.xml
@@ -26,7 +26,7 @@
             </action>
         </referenceBlock>
         <referenceBlock name="tweakwise.catalog.product.list.visual">
-            <action method="setTemplate" ifconfig="tweakwise/personal_merchandising/enabled">
+            <action method="setTemplate">
                 <argument name="template" xsi:type="string">Tweakwise_TweakwiseHyva::product/list/visual.phtml</argument>
             </action>
         </referenceBlock>


### PR DESCRIPTION
With this fix it is possible to show visuals without Merchandising and AJAX filtering enabled