### PR TITLE
Fix: color swatch selected

### DIFF
--- a/src/view/frontend/templates/product/layered/swatch.phtml
+++ b/src/view/frontend/templates/product/layered/swatch.phtml
@@ -125,10 +125,9 @@ if (!$swatchData['swatches']) {
                             }; tooltipPositionElement = $event.target;"
                             @mouseleave.self="activeTooltipItem = false"
                         <?php endif; ?>
-                    >
                         <input id="<?= $escaper->escapeHtmlAttr($cssId) ?>" style="display: none"
                                name="<?= $escaper->escapeHtmlAttr($item->getFilter()->getFacet()->getFacetSettings()->getUrlKey()) ?>[]"
-                               type="checkbox" <?= $escaper->escapeHtmlAttr($item->isSelected() ? 'checked="checked"' : '') ?>
+                               type="checkbox" <?= /* @noEscape */ $item->isSelected() ? 'checked="checked"' : '' ?>
                                value="<?= $escaper->escapeHtmlAttr($item->getLabel()) ?>"
                         >
                         <?php if ((string)$type === "0"): ?>

--- a/src/view/frontend/templates/product/layered/swatch.phtml
+++ b/src/view/frontend/templates/product/layered/swatch.phtml
@@ -125,6 +125,7 @@ if (!$swatchData['swatches']) {
                             }; tooltipPositionElement = $event.target;"
                             @mouseleave.self="activeTooltipItem = false"
                         <?php endif; ?>
+                    >
                         <input id="<?= $escaper->escapeHtmlAttr($cssId) ?>" style="display: none"
                                name="<?= $escaper->escapeHtmlAttr($item->getFilter()->getFacet()->getFacetSettings()->getUrlKey()) ?>[]"
                                type="checkbox" <?= /* @noEscape */ $item->isSelected() ? 'checked="checked"' : '' ?>


### PR DESCRIPTION
**How to reproduce**

- Enable the query url parameter stategy. 
- Select an color from the color swatch. For example yellow
- See that the link to select another color filter contains yellow. For example the link to select blue would be color=yellow&color=blue
- Click on that color

**Expected result**

You should be on the url with both yellow and blue selected. color=yellow&color=blue

**Actual result**

See that only the last selected color is in the url. color=blue and that yellow is no longer selected.