### PR TITLE
Feat: new suggestions endpoint

### DIFF
--- a/src/view/frontend/templates/html/header/search-form.phtml
+++ b/src/view/frontend/templates/html/header/search-form.phtml
@@ -41,7 +41,7 @@ $helper = $block->getData('tweakwiseSearchForm')->getSearchHelper();
             },
             fetchSuggestions(term) {
                 fetch(
-                    window.BASE_URL + 'search/ajax/suggest?' + new URLSearchParams({q: term}),
+                    window.BASE_URL + 'search/ajax/suggest/blocks/1?' + new URLSearchParams({q: term}),
                     {
                         headers: {
                             'X-Requested-With': 'XMLHttpRequest'

--- a/src/view/frontend/templates/quick-search.phtml
+++ b/src/view/frontend/templates/quick-search.phtml
@@ -38,8 +38,8 @@ use Magento\Framework\View\Element\Template;
                                 @click="clickSuggestion(item)"
                                 @keydown.enter="clickSuggestion(item)"
                                 @keydown.arrow-up.prevent="focusElement($event.target.previousElementSibling) || $refs.searchInput.focus()"
-                                @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)"
-                                <template x-if="item.image">
+                                @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)">
+                                 <template x-if="item.image">
                                     <img class="qs-option-image mr-2" :src="item.image" :alt="item.title"/>
                                 </template>
 

--- a/src/view/frontend/templates/quick-search.phtml
+++ b/src/view/frontend/templates/quick-search.phtml
@@ -33,51 +33,56 @@ use Magento\Framework\View\Element\Template;
                             <span x-text="suggestion.block.name"></span>
                         </div>
 
-                        <template x-for="(item, index) in suggestion.block.items">
-                            <div
-                                class="product-item flex p-2 cursor-pointer border-b border-container focus:bg-container-darker hover:bg-container-darker"
-                                :class="item.row_class"
-                                :data-url="item.url"
-                                role="option">
-                                <template x-if="item.image">
-                                    <img class="qs-option-image mr-2" :src="item.image" :alt="item.title"/>
-                                </template>
-
-                                <div class="qs-option-info-container">
-                                    <template x-if="item.type !== 'visual'">
-                                        <div class="qs-option-name" x-text="item.title"></div>
-                                    </template>
-
-                                    <div class="price-box">
-                                        <template x-if="Math.abs(item.final_price - item.price) < 0.0001">
-                                            <span class="price-container">
-                                                <span class="price-wrapper">
-                                                    <span x-html="formatPrice(item.price)" class="price"></span>
-                                                </span>
-                                            </span>
+                        <template x-for="(row, rowIndex) in groupItemsIntoRows(suggestion.block.items, 3)">
+                            <div class="qs-row">
+                                <template x-for="item in row">
+                                    <div
+                                        class="product-item flex p-2 cursor-pointer border-b border-container focus:bg-container-darker hover:bg-container-darker"
+                                        :class="item.row_class"
+                                        :data-url="item.url"
+                                        role="option"
+                                        :style="`grid-column: span ${(item.visualproperties?.colspan || 1)}; grid-row: span ${(item.visualproperties?.rowspan || 1)}; max-height: ${(item.visualproperties?.rowspan || 1) * 100}px;`">
+                                        <template x-if="item.image">
+                                            <img class="qs-option-image mr-2" :src="item.image" :alt="item.title"/>
                                         </template>
 
-                                        <template x-if="Math.abs(item.final_price - item.price) >= 0.0001">
-                                            <span class="special-price">
-                                                <span class="price-container">
-                                                    <span class="price-label hidden"><?= $escaper->escapeHtml(__('Special Price'))?></span>
-                                                    <span class="price-wrapper">
-                                                        <span x-html="formatPrice(item.final_price)" class="price"></span>
-                                                    </span>
-                                                </span>
-                                            </span>
+                                        <div class="qs-option-info-container">
+                                            <template x-if="item.type !== 'visual'">
+                                                <div class="qs-option-name" x-text="item.title"></div>
+                                            </template>
 
-                                            <span class="old-price sly-old-price">
-                                                <span class="price-container">
-                                                    <span class="price-label hidden"><?= $escaper->escapeHtml(__('Regular Price'))?></span>
-                                                    <span class="price-wrapper">
-                                                        <span x-html="formatPrice(item.price)" class="price"></span>
+                                            <div class="price-box">
+                                                <template x-if="Math.abs(item.final_price - item.price) < 0.0001">
+                                                    <span class="price-container">
+                                                        <span class="price-wrapper">
+                                                            <span x-html="formatPrice(item.price)" class="price"></span>
+                                                        </span>
                                                     </span>
-                                                </span>
-                                            </span>
-                                        </template>
+                                                </template>
+
+                                                <template x-if="Math.abs(item.final_price - item.price) >= 0.0001">
+                                                    <span class="special-price">
+                                                        <span class="price-container">
+                                                            <span class="price-label hidden"><?= $escaper->escapeHtml(__('Special Price'))?></span>
+                                                            <span class="price-wrapper">
+                                                                <span x-html="formatPrice(item.final_price)" class="price"></span>
+                                                            </span>
+                                                        </span>
+                                                    </span>
+
+                                                    <span class="old-price sly-old-price">
+                                                        <span class="price-container">
+                                                            <span class="price-label hidden"><?= $escaper->escapeHtml(__('Regular Price'))?></span>
+                                                            <span class="price-wrapper">
+                                                                <span x-html="formatPrice(item.price)" class="price"></span>
+                                                            </span>
+                                                        </span>
+                                                    </span>
+                                                </template>
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
+                                </template>
                             </div>
                         </template>
                     </div>
@@ -122,3 +127,44 @@ use Magento\Framework\View\Element\Template;
         </template>
     </div>
 </template>
+
+<style>
+.qs-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr); /* Ensure 3 columns per row */
+    gap: 10px; /* Add spacing between items */
+}
+
+.product-item {
+    grid-column: span 1; /* Default column span */
+}
+
+.qs-option-image {
+    width: auto;
+    height: 100%;
+}
+</style>
+
+<script>
+function groupItemsIntoRows(items, itemsPerRow) {
+    if (!items || items.length === 0) return [];
+
+    // Normalize items to always be a flat array
+    let normalizedItems;
+    if (items.item && Array.isArray(items.item)) {
+        normalizedItems = items.item;
+    } else if (items.item && typeof items.item === 'object') {
+        normalizedItems = [items.item]; // Wrap single object in an array
+    } else if (Array.isArray(items)) {
+        normalizedItems = Array.isArray(items[0]) ? items.flat() : items;
+    } else {
+        normalizedItems = [items];
+    }
+
+    const rows = [];
+    for (let i = 0; i < normalizedItems.length; i += itemsPerRow) {
+        rows.push(normalizedItems.slice(i, i + itemsPerRow));
+    }
+    return rows;
+}
+</script>

--- a/src/view/frontend/templates/quick-search.phtml
+++ b/src/view/frontend/templates/quick-search.phtml
@@ -29,60 +29,55 @@ use Magento\Framework\View\Element\Template;
                             <span x-text="suggestion.block.name"></span>
                         </div>
 
-                        <template x-for="(row, rowIndex) in groupItemsIntoRows(suggestion.block.items, 3)">
-                            <div class="qs-row">
-                                <template x-for="item in row">
-                                    <div
-                                        class="product-item flex p-2 cursor-pointer border-b border-container focus:bg-container-darker hover:bg-container-darker"
-                                        :class="item.row_class"
-                                        :data-url="item.url"
-                                        role="option"
-                                        @click="clickSuggestion(item)"
-                                        @keydown.enter="clickSuggestion(item)"
-                                        @keydown.arrow-up.prevent="focusElement($event.target.previousElementSibling) || $refs.searchInput.focus()"
-                                        @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)"
-                                        :style="`grid-column: span ${(item.visualproperties?.colspan || 1)}; grid-row: span ${(item.visualproperties?.rowspan || 1)}; max-height: ${(item.visualproperties?.rowspan || 1) * 100}px;`">
-                                        <template x-if="item.image">
-                                            <img class="qs-option-image mr-2" :src="item.image" :alt="item.title"/>
+                        <template x-for="item in suggestion.block.items">
+                            <div
+                                class="product-item flex p-2 cursor-pointer border-b border-container focus:bg-container-darker hover:bg-container-darker"
+                                :class="item.row_class"
+                                :data-url="item.url"
+                                role="option"
+                                @click="clickSuggestion(item)"
+                                @keydown.enter="clickSuggestion(item)"
+                                @keydown.arrow-up.prevent="focusElement($event.target.previousElementSibling) || $refs.searchInput.focus()"
+                                @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)"
+                                <template x-if="item.image">
+                                    <img class="qs-option-image mr-2" :src="item.image" :alt="item.title"/>
+                                </template>
+
+                                <div class="qs-option-info-container">
+                                    <template x-if="item.type !== 'visual'">
+                                        <div class="qs-option-name" x-text="item.title"></div>
+                                    </template>
+
+                                    <div class="price-box">
+                                        <template x-if="Math.abs(item.final_price - item.price) < 0.0001">
+                                            <span class="price-container">
+                                                <span class="price-wrapper">
+                                                    <span x-html="formatPrice(item.price)" class="price"></span>
+                                                </span>
+                                            </span>
                                         </template>
 
-                                        <div class="qs-option-info-container">
-                                            <template x-if="item.type !== 'visual'">
-                                                <div class="qs-option-name" x-text="item.title"></div>
-                                            </template>
-
-                                            <div class="price-box">
-                                                <template x-if="Math.abs(item.final_price - item.price) < 0.0001">
-                                                    <span class="price-container">
-                                                        <span class="price-wrapper">
-                                                            <span x-html="formatPrice(item.price)" class="price"></span>
-                                                        </span>
+                                        <template x-if="Math.abs(item.final_price - item.price) >= 0.0001">
+                                            <span class="special-price">
+                                                <span class="price-container">
+                                                    <span class="price-label hidden"><?= $escaper->escapeHtml(__('Special Price'))?></span>
+                                                    <span class="price-wrapper">
+                                                        <span x-html="formatPrice(item.final_price)" class="price"></span>
                                                     </span>
-                                                </template>
+                                                </span>
+                                            </span>
 
-                                                <template x-if="Math.abs(item.final_price - item.price) >= 0.0001">
-                                                    <span class="special-price">
-                                                        <span class="price-container">
-                                                            <span class="price-label hidden"><?= $escaper->escapeHtml(__('Special Price'))?></span>
-                                                            <span class="price-wrapper">
-                                                                <span x-html="formatPrice(item.final_price)" class="price"></span>
-                                                            </span>
-                                                        </span>
+                                            <span class="old-price sly-old-price">
+                                                <span class="price-container">
+                                                    <span class="price-label hidden"><?= $escaper->escapeHtml(__('Regular Price'))?></span>
+                                                    <span class="price-wrapper">
+                                                        <span x-html="formatPrice(item.price)" class="price"></span>
                                                     </span>
-
-                                                    <span class="old-price sly-old-price">
-                                                        <span class="price-container">
-                                                            <span class="price-label hidden"><?= $escaper->escapeHtml(__('Regular Price'))?></span>
-                                                            <span class="price-wrapper">
-                                                                <span x-html="formatPrice(item.price)" class="price"></span>
-                                                            </span>
-                                                        </span>
-                                                    </span>
-                                                </template>
-                                            </div>
-                                        </div>
+                                                </span>
+                                            </span>
+                                        </template>
                                     </div>
-                                </template>
+                                </div>
                             </div>
                         </template>
                     </div>
@@ -127,53 +122,3 @@ use Magento\Framework\View\Element\Template;
         </template>
     </div>
 </template>
-
-<style>
-.qs-row {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr); /* Ensure 3 columns per row */
-    gap: 10px; /* Add spacing between items */
-}
-
-.product-item {
-    grid-column: span 1; /* Default column span */
-}
-
-.qs-option-image {
-    width: auto;
-    height: 100%;
-}
-</style>
-
-<script>
-function groupItemsIntoRows(items, itemsPerRow) {
-    if (!items || items.length === 0) return [];
-
-    // Normalize items to always be a flat array
-    let normalizedItems;
-    if (items.item && Array.isArray(items.item)) {
-        normalizedItems = items.item;
-    } else if (items.item && typeof items.item === 'object') {
-        normalizedItems = [items.item]; // Wrap single object in an array
-    } else if (Array.isArray(items)) {
-        normalizedItems = Array.isArray(items[0]) ? items.flat() : items;
-    } else {
-        normalizedItems = [items];
-    }
-
-    // Adjust items to switch last item with the next if colspan > 1
-    for (let i = 2; i < normalizedItems.length - 1; i += itemsPerRow) {
-        if (normalizedItems[i]?.visualproperties?.colspan > 1) {
-            const temp = normalizedItems[i + 1];
-            normalizedItems[i + 1] = normalizedItems[i];
-            normalizedItems[i] = temp;
-        }
-    }
-
-    const rows = [];
-    for (let i = 0; i < normalizedItems.length; i += itemsPerRow) {
-        rows.push(normalizedItems.slice(i, i + itemsPerRow));
-    }
-    return rows;
-}
-</script>

--- a/src/view/frontend/templates/quick-search.phtml
+++ b/src/view/frontend/templates/quick-search.phtml
@@ -22,10 +22,6 @@ use Magento\Framework\View\Element\Template;
                  role="option"
                  tabindex="0"
                  :data-title="suggestion.title ? suggestion.title : ''"
-                 @click="clickSuggestion(suggestion)"
-                 @keydown.enter="clickSuggestion(suggestion)"
-                 @keydown.arrow-up.prevent="focusElement($event.target.previousElementSibling) || $refs.searchInput.focus()"
-                 @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)"
             >
                 <template x-if="suggestion.block && suggestion.block.nrofitems > 0">
                     <div>
@@ -41,6 +37,10 @@ use Magento\Framework\View\Element\Template;
                                         :class="item.row_class"
                                         :data-url="item.url"
                                         role="option"
+                                        @click="clickSuggestion(item)"
+                                        @keydown.enter="clickSuggestion(item)"
+                                        @keydown.arrow-up.prevent="focusElement($event.target.previousElementSibling) || $refs.searchInput.focus()"
+                                        @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)"
                                         :style="`grid-column: span ${(item.visualproperties?.colspan || 1)}; grid-row: span ${(item.visualproperties?.rowspan || 1)}; max-height: ${(item.visualproperties?.rowspan || 1) * 100}px;`">
                                         <template x-if="item.image">
                                             <img class="qs-option-image mr-2" :src="item.image" :alt="item.title"/>

--- a/src/view/frontend/templates/quick-search.phtml
+++ b/src/view/frontend/templates/quick-search.phtml
@@ -27,43 +27,59 @@ use Magento\Framework\View\Element\Template;
                  @keydown.arrow-up.prevent="focusElement($event.target.previousElementSibling) || $refs.searchInput.focus()"
                  @keydown.arrow-down.prevent="focusElement($event.target.nextElementSibling)"
             >
-                <template x-if="suggestion.type === 'product'">
-                    <div class="product-item flex p-2 cursor-pointer border-b border-container focus:bg-container-darker hover:bg-container-darker">
-                        <template x-if="suggestion.image">
-                            <img class="qs-option-image mr-2" :src="suggestion.image ? suggestion.image: ''"
-                                 :alt="suggestion.title ? suggestion.title : ''"/>
-                        </template>
-
-                        <div class="qs-option-info-container">
-                            <div class="qs-option-name" x-text="suggestion.title"></div>
-                            <div class="price-box">
-                                <template x-if="!hasSpecialPrice(suggestion)">
-                                    <span class="price-container">
-                                        <span class="price-wrapper">
-                                            <span x-html="formatPrice(suggestion.price)" class="price"></span>
-                                        </span>
-                                    </span>
-                                </template>
-
-                                <template x-if="hasSpecialPrice(suggestion)">
-                                    <span class="price-container">
-                                        <span class="old-price sly-old-price mr-1">
-                                            <span class="price-label hidden"><?= $escaper->escapeHtml(__('Regular Price'))?></span>
-                                            <span class="price-wrapper">
-                                                <span x-html="formatPrice(suggestion.price)"
-                                                      class="price font-regular line-through text-gray-900"></span>
-                                            </span>
-                                        </span>
-                                        <span class="special-price">
-                                            <span class="price-label hidden"><?= $escaper->escapeHtml(__('Special Price'))?></span>
-                                            <span class="price-wrapper">
-                                                <span x-html="formatPrice(suggestion.final_price)" class="price"></span>
-                                            </span>
-                                        </span>
-                                    </span>
-                                </template>
-                            </div>
+                <template x-if="suggestion.block && suggestion.block.nrofitems > 0">
+                    <div>
+                        <div class="qs-suggestion-heading font-bold p-2">
+                            <span x-text="suggestion.block.name"></span>
                         </div>
+
+                        <template x-for="(item, index) in suggestion.block.items">
+                            <div
+                                class="product-item flex p-2 cursor-pointer border-b border-container focus:bg-container-darker hover:bg-container-darker"
+                                :class="item.row_class"
+                                :data-url="item.url"
+                                role="option">
+                                <template x-if="item.image">
+                                    <img class="qs-option-image mr-2" :src="item.image" :alt="item.title"/>
+                                </template>
+
+                                <div class="qs-option-info-container">
+                                    <template x-if="item.type !== 'visual'">
+                                        <div class="qs-option-name" x-text="item.title"></div>
+                                    </template>
+
+                                    <div class="price-box">
+                                        <template x-if="Math.abs(item.final_price - item.price) < 0.0001">
+                                            <span class="price-container">
+                                                <span class="price-wrapper">
+                                                    <span x-html="formatPrice(item.price)" class="price"></span>
+                                                </span>
+                                            </span>
+                                        </template>
+
+                                        <template x-if="Math.abs(item.final_price - item.price) >= 0.0001">
+                                            <span class="special-price">
+                                                <span class="price-container">
+                                                    <span class="price-label hidden"><?= $escaper->escapeHtml(__('Special Price'))?></span>
+                                                    <span class="price-wrapper">
+                                                        <span x-html="formatPrice(item.final_price)" class="price"></span>
+                                                    </span>
+                                                </span>
+                                            </span>
+
+                                            <span class="old-price sly-old-price">
+                                                <span class="price-container">
+                                                    <span class="price-label hidden"><?= $escaper->escapeHtml(__('Regular Price'))?></span>
+                                                    <span class="price-wrapper">
+                                                        <span x-html="formatPrice(item.price)" class="price"></span>
+                                                    </span>
+                                                </span>
+                                            </span>
+                                        </template>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
                     </div>
                 </template>
 

--- a/src/view/frontend/templates/quick-search.phtml
+++ b/src/view/frontend/templates/quick-search.phtml
@@ -161,6 +161,15 @@ function groupItemsIntoRows(items, itemsPerRow) {
         normalizedItems = [items];
     }
 
+    // Adjust items to switch last item with the next if colspan > 1
+    for (let i = 2; i < normalizedItems.length - 1; i += itemsPerRow) {
+        if (normalizedItems[i]?.visualproperties?.colspan > 1) {
+            const temp = normalizedItems[i + 1];
+            normalizedItems[i + 1] = normalizedItems[i];
+            normalizedItems[i] = temp;
+        }
+    }
+
     const rows = [];
     for (let i = 0; i < normalizedItems.length; i += itemsPerRow) {
         rows.push(normalizedItems.slice(i, i + itemsPerRow));


### PR DESCRIPTION
## 📝 Description
This PR implements support for the new Tweakwise Suggestions endpoint. 

**Note:** This PR depends on [EmicoEcommerce/Magento2Tweakwise/pull/350](https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/350), which must be merged/available for this functionality to work correctly.

## ⚠️ Upgrade Guide
If you have a custom override for `quicksearch.phtml`, you must perform one of the following actions to avoid breaking the search functionality:

1. **To use the new functionality:** Copy the changes from the base `quicksearch.phtml` into your custom override file.
2. **To retain legacy functionality:** In `search-form.phtml`, locate line 44 and modify the URL by changing `/blocks/1` to `/blocks/0`.

## 🧪 Testing Plan
To verify the new suggestions endpoint, follow these steps:

* [ ] **Configuration:** In the Tweakwise backend, add new item types to the suggestions configuration.
* [ ] **Linking:** Ensure that any items expected under these new types are correctly linked to the relevant categories.
* [ ] **Validation:** Compare the suggestions displayed in your local environment with those in the [Tweakwise Demoshop](https://demoshop.tweakwise.com/) to ensure data parity and accuracy.

---
## ✅ Checklist
- [ ] Dependency PR #350 is present.
- [ ] Verified `quicksearch.phtml` changes or legacy fallback.
- [ ] Suggestion item types match Tweakwise Demoshop.