### PR TITLE
feat: Add product count fetch for filter buttons

### DIFF
--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -23,12 +23,14 @@ use Magento\Framework\View\Element\Template;
             formFilters: false,
             seoEnabled: false,
             ajaxEndpoint: '/tweakwise/ajax/navigation',
+            countEndpoint: '/tweakwise/ajax/productcount',
             filterFormSelector: '#facet-filter-form',
             filterSelector: '#facet-filter-form',
             productListSelector: '.products.wrapper',
             toolbarSelector: '.toolbar.toolbar-products',
             isLoading: false,
             currentXhr: null,
+            countFetchController: null,
             fetchController: null,
             ajaxCache: true,
             urlStrategy: null,
@@ -42,6 +44,7 @@ use Magento\Framework\View\Element\Template;
 
                 if (filterOptions) {
                     this.ajaxEndpoint = filterOptions.ajaxEndpoint;
+                    this.countEndpoint = filterOptions.countEndpoint || this.countEndpoint;
                     this.ajaxFilters = filterOptions.ajaxFilters;
                     this.formFilters = filterOptions.formFilters;
                     this.seoEnabled = filterOptions.seoEnabled;
@@ -63,6 +66,10 @@ use Magento\Framework\View\Element\Template;
                         this.pmListReload(pmOptions.cookieName);
                     }
                 }
+
+                if (this.formFilters) {
+                    this.bindCountUpdateEvents();
+                }
             },
             bindFilterClickEvents() {
                 const filterForm = document.querySelector(this.filterFormSelector);
@@ -81,6 +88,81 @@ use Magento\Framework\View\Element\Template;
                 } else {
                     filterForm.addEventListener('change', (event) => this.defaultHandler(event));
                 }
+            },
+
+            /**
+             * Bind change events on filter inputs to update the "Show X items" button count.
+             * Only active when formFilters is enabled.
+             */
+            bindCountUpdateEvents() {
+                const filterForm = document.querySelector(this.filterFormSelector);
+
+                if (!filterForm) {
+                    return;
+                }
+
+                filterForm.addEventListener('change', (event) => {
+                    if (event.target.classList.contains('js-skip-submit')) {
+                        return;
+                    }
+
+                    this.fetchAndUpdateCount();
+                });
+            },
+
+            /**
+             * Fire a lightweight AJAX request to retrieve the product count for the current
+             * filter selection and update all "Show X items" buttons in the filter block.
+             */
+            fetchAndUpdateCount() {
+                if (this.countFetchController) {
+                    this.countFetchController.abort();
+                }
+
+                const filterParams = this.getFilterParameters();
+                let fetchUrl = this.countEndpoint;
+
+                if (filterParams) {
+                    fetchUrl = `${fetchUrl}?${filterParams}`;
+                }
+
+                this.countFetchController = new AbortController();
+
+                fetch(fetchUrl, { signal: this.countFetchController.signal, cache: 'no-cache' })
+                    .then(response => response.json())
+                    .then(response => {
+                        if (typeof response.product_count !== 'undefined') {
+                            this.updateFilterButtonCount(response.product_count);
+                        }
+                    })
+                    .catch((error) => {
+                        if (error.name !== 'AbortError') {
+                            console.error('Error fetching product count:', error);
+                        }
+                    });
+            },
+
+            /**
+             * Update the label of all "Show X items" buttons with the given product count.
+             *
+             * @param {number} count
+             */
+            updateFilterButtonCount(count) {
+                const filterForm = document.querySelector(this.filterFormSelector);
+
+                if (!filterForm) {
+                    return;
+                }
+
+                filterForm.querySelectorAll('.js-btn-filter').forEach((button) => {
+                    const label = button.dataset.countLabel || '';
+                    const text = label.replace('%count%', count);
+
+                    if (text) {
+                        button.textContent = text;
+                        button.setAttribute('aria-label', text);
+                    }
+                });
             },
 
             /**
@@ -246,6 +328,10 @@ use Magento\Framework\View\Element\Template;
                     .then(response => {
                         this.ajaxUpdateBlocks(response.html);
                         this.ajaxUpdateState(response);
+
+                        if (typeof response.product_count !== 'undefined') {
+                            this.updateFilterButtonCount(response.product_count);
+                        }
                     })
                     .catch((error) => {
                         if (error.name !== 'AbortError') {

--- a/src/view/frontend/templates/layer/view.phtml
+++ b/src/view/frontend/templates/layer/view.phtml
@@ -32,10 +32,9 @@ $hasFilters = count($filters) > 0;
 $filtered = count($block->getLayer()->getState()->getFilters());
 
 if ($renderFilterButton) {
-    /** @var \Magento\Framework\Phrase $showItemsLabel */
-    $showItemsLabel = __('Show %count% items');
+    $showItemsLabel = __('Show %count% items')->render();
     $productCount = $block->getLayer()->getProductCollection()->getSize();
-    $showItemsText = __('Show %1 items', $productCount);
+    $showItemsText = __('Show %1 items', $productCount)->render();
 }
 ?>
 
@@ -161,10 +160,10 @@ if ($renderFilterButton) {
                                     <div class="show-items-link">
                                         <button type="button"
                                                 class="btn btn-primary btn-block js-btn-filter"
-                                                data-count-label="<?= $escaper->escapeHtmlAttr((string) $showItemsLabel) ?>"
-                                                aria-label="<?= $escaper->escapeHtmlAttr((string) $showItemsText) ?>"
+                                                 data-count-label="<?= $escaper->escapeHtmlAttr($showItemsLabel) ?>"
+                                                aria-label="<?= $escaper->escapeHtmlAttr($showItemsText) ?>"
                                         >
-                                            <?= $escaper->escapeHtml((string) $showItemsText); ?>
+                                            <?= $escaper->escapeHtml($showItemsText); ?>
                                         </button>
                                     </div>
                                 <?php endif; ?>

--- a/src/view/frontend/templates/layer/view.phtml
+++ b/src/view/frontend/templates/layer/view.phtml
@@ -30,6 +30,13 @@ $renderFilterButton = $tweakwiseNavigationConfig->isFormFilters();
 
 $hasFilters = count($filters) > 0;
 $filtered = count($block->getLayer()->getState()->getFilters());
+
+if ($renderFilterButton) {
+    /** @var \Magento\Framework\Phrase $showItemsLabel */
+    $showItemsLabel = __('Show %count% items');
+    $productCount = $block->getLayer()->getProductCollection()->getSize();
+    $showItemsText = __('Show %1 items', $productCount);
+}
 ?>
 
     <div class="block filter border border-container bg-container p-2 md:p-0 md:border-0 md:bg-transparent my-6<?=(!$hasFilters ? ' filter-no-options' : '')?>"
@@ -154,10 +161,10 @@ $filtered = count($block->getLayer()->getState()->getFilters());
                                     <div class="show-items-link">
                                         <button type="button"
                                                 class="btn btn-primary btn-block js-btn-filter"
-                                                aria-label="<?= $escaper->escapeHtmlAttr(__('Apply filters')) ?>"
+                                                data-count-label="<?= $escaper->escapeHtmlAttr((string) $showItemsLabel) ?>"
+                                                aria-label="<?= $escaper->escapeHtmlAttr((string) $showItemsText) ?>"
                                         >
-                                            <?= $escaper->escapeHtml(__('Show items')); ?>
-
+                                            <?= $escaper->escapeHtml((string) $showItemsText); ?>
                                         </button>
                                     </div>
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary

- Mirrors the filter count feature from [EmicoEcommerce/Magento2Tweakwise#372](https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/372) for the Hyvä compatibility layer.
- On initial page load, the "Show X items" button now displays the actual product count for the current category/search context instead of the generic "Show items" label.
- On every filter checkbox change (when `formFilters` is enabled), a lightweight AJAX request is fired to `tweakwise/ajax/productcount` and all "Show X items" buttons are updated without triggering a full navigation reload.
- When AJAX filters are enabled and a navigation response is returned, the button count is also updated from the `product_count` field included in the response (added in #372).
- In-flight count requests are aborted when a new filter change fires, preventing stale count updates.

## How to test

**Setup**

1. Enable both `tweakwise/layered/enabled` and `tweakwise/layered/form_filters` in Stores → Configuration → Tweakwise.
2. Make sure the branch from [EmicoEcommerce/Magento2Tweakwise#372](https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/372) is active in `vendor/tweakwise/magento2-tweakwise`.
3. Navigate to a category page with Tweakwise facets, e.g. `/women/tops-women/`.

---

**Scenario 1 — Initial page load**

1. Open the category page.
2. Each "Show X items" button should display the actual product count for that category, not the generic "Show items" label.

---

**Scenario 2 — Single filter checkbox**

1. Check one filter value (e.g. size M).
2. Without clicking the button, observe all "Show X items" buttons update to reflect the new count.
3. Verify the count matches what Tweakwise returns for that category + filter combination.

---

**Scenario 3 — Multiple filters combined**

1. Check a second filter value (e.g. color Gray) while size M is still checked.
2. All buttons should update to the combined count (category + size M + color Gray).
3. Uncheck one filter; buttons should update back to the count for the remaining filter only.

---

**Scenario 4 — Full filter apply still works**

1. Check a filter and click the "Show X items" button.
2. The page should navigate/reload with the filter applied as before.

---

**Scenario 5 — `formFilters` disabled**

1. Disable `tweakwise/layered/form_filters`.
2. Verify no count AJAX requests are fired on filter changes (the feature is inactive).