### PR TITLE
fix: update canonical tag on AJAX navigation

### DIFF
--- a/src/view/frontend/templates/layer/navigation-form.phtml
+++ b/src/view/frontend/templates/layer/navigation-form.phtml
@@ -246,6 +246,7 @@ use Magento\Framework\View\Element\Template;
                     .then(response => {
                         this.ajaxUpdateBlocks(response.html);
                         this.ajaxUpdateState(response);
+                        this.ajaxUpdateCanonical(response.canonical);
                     })
                     .catch((error) => {
                         if (error.name !== 'AbortError') {
@@ -354,6 +355,15 @@ use Magento\Framework\View\Element\Template;
 
             ajaxUpdateState(response) {
                 window.history.pushState({html: response.html}, '', response.url);
+            },
+            ajaxUpdateCanonical(canonical) {
+                if (!canonical) {
+                    return;
+                }
+                const canonicalTag = document.querySelector('link[rel="canonical"]');
+                if (canonicalTag) {
+                    canonicalTag.setAttribute('href', canonical);
+                }
             },
             ajaxStartLoader() {
                 this.isLoading = true;


### PR DESCRIPTION
Companion PR to [EmicoEcommerce/Magento2Tweakwise#389](https://github.com/EmicoEcommerce/Magento2Tweakwise/pull/389).

The Hyva theme uses its own inline vanilla JS implementation in `navigation-form.phtml` (no RequireJS). Without this change the canonical tag would not be updated after AJAX navigation on Hyva storefronts, even with the main module's fix applied.

**Changes:**

- `src/view/frontend/templates/layer/navigation-form.phtml` — adds `ajaxUpdateCanonical(canonical)` method and calls it in the `fetch()` success handler. Updates `href` on the existing `<link rel="canonical">` tag if present; does nothing if no canonical tag exists.

## How to test

**Scenario 1 — AJAX navigation updates canonical (Hyva)**

1. Enable Hyva theme. Set `tweakwise/layered/enabled = 1`, `tweakwise/layered/ajax_filters = 1`, `catalog/seo/category_canonical_tag = 1`, `tweakwise/seo/paginated_canonical_enabled = 1`. Run `cache:clean` and redeploy static content.
2. Open a category page on the Hyva storefront.
3. Inspect `<link rel="canonical">` in DevTools — note the initial value.
4. Apply a filter. After the AJAX response, canonical should reflect the current filtered URL.
5. Navigate to page 2. Canonical should include `?p=2`.

---

**Scenario 2 — No canonical tag present, nothing added**

1. Set `catalog/seo/category_canonical_tag = 0`. Run `cache:clean`.
2. Load a category page — confirm no canonical in `<head>`.
3. Apply a filter via AJAX — confirm no canonical is inserted.

---