### PR TITLE
fix: render visual tiles on search result pages with category match

### DIFF
--- a/src/view/frontend/layout/hyva_catalogsearch_result_index.xml
+++ b/src/view/frontend/layout/hyva_catalogsearch_result_index.xml
@@ -22,5 +22,10 @@
                 <argument name="template" xsi:type="string">Tweakwise_Magento2Tweakwise::product/list/toolbar.phtml</argument>
             </action>
         </referenceBlock>
+        <referenceBlock name="tweakwise.catalog.product.list.visual">
+            <action method="setTemplate">
+                <argument name="template" xsi:type="string">Tweakwise_TweakwiseHyva::product/list/visual.phtml</argument>
+            </action>
+        </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
When Tweakwise returns a Visual tile in search results (e.g. when a search query triggers a category match), the Visual was not shown. This adds the Hyva template override for the Visual block on the search result page, consistent with how `hyva_catalog_category_view.xml` handles it for category pages.

- `src/view/frontend/layout/hyva_catalogsearch_result_index.xml` — added `<referenceBlock>` to override `tweakwise.catalog.product.list.visual` template to `Tweakwise_TweakwiseHyva::product/list/visual.phtml`. The Hyva AJAX search layout (`hyva_tweakwise_ajax_search.xml`) inherits this automatically via `<update handle="hyva_catalogsearch_result_index"/>`.
- Main module PR: EmicoEcommerce/Magento2Tweakwise#390

## How to test

**Scenario 1 — Visual renders on Hyva search page with category match**

1. On a Hyva storefront, perform a search query that triggers a category match (e.g. `bags`).
2. **Expected:** The Visual tile renders correctly using the Hyva visual template at the correct grid position.

---

**Scenario 2 — Category page Visuals still render on Hyva**

1. Navigate to a category page with a Visual configured in its builder.
2. **Expected:** Visual tile renders correctly — unchanged behaviour.

---

**Scenario 3 — AJAX filtering on Hyva search preserves Visual**

1. On the Hyva search result page from scenario 1, apply a facet filter via AJAX.
2. **Expected:** The Visual tile remains at the correct position after filtering.

---
