### PR TITLE
feat: show result count on colorbox swatch filter options in Hyva theme

### DIFF
--- a/src/view/frontend/templates/product/layered/swatch.phtml
+++ b/src/view/frontend/templates/product/layered/swatch.phtml
@@ -111,7 +111,7 @@ if (!$swatchData['swatches']) {
                 ?>
 
                 <a <?= /* @noEscape */$block->renderAnchorHtmlTagAttributes($item); ?>
-                        class="swatch-option-link-layered swatch-option cursor-pointer select-none m-1 flex border justify-center"
+                        class="swatch-option-link-layered swatch-option cursor-pointer select-none m-1 flex flex-col items-center border justify-center"
                         :class="{ 'block': moreItemsShow, 'hidden': '<?= $escaper->escapeHtmlAttr($block->itemDefaultHidden($item))?>' && !moreItemsShow }"
                         tabindex="0"
                         role="button"
@@ -144,6 +144,11 @@ if (!$swatchData['swatches']) {
                             <?= $escaper->escapeHtml($value ?: $label['label']) ?>
                         <?php endif; ?>
                     </label>
+                    <?php if ($block->shouldDisplayProductCountOnLayer()): ?>
+                        <span class="count text-xs text-primary">
+                            (<?= $escaper->escapeHtml($item->getCount()) ?>)
+                        </span>
+                    <?php endif; ?>
                 </a>
             <?php } ?>
         <?php endforeach; ?>


### PR DESCRIPTION
## Summary

In Tweakwise, a filter attribute can be configured to show the number of matching products next to each option (the "Show amount of results" setting). For **Colorbox**-type filters this worked in the Luma theme but was silently missing in the Hyvä theme — shoppers saw the colored swatches with no counts at all.

This fix brings the Hyvä colorbox filter in line with Luma: when "Show amount of results" is enabled in the filter template, each swatch option now shows a `(N)` count below the color box.

### Changes

| File | What changed |
|---|---|
| `src/view/frontend/templates/product/layered/swatch.phtml` | Render result count below each swatch when `shouldDisplayProductCountOnLayer()` is true |
| `src/view/frontend/templates/product/layered/swatch.phtml` | Changed flex direction to `flex-col items-center` so the count stacks below the swatch box |

## How to test

**Scenario 1 — Count is shown when "Show amount of results" is enabled**

1. In the Tweakwise Navigator app, open the filter template for your category. Set a color attribute to display type **Colorbox** and enable **Show amount of results**.
2. Run `bin/magento cache:clean`.
3. Open the category page in a Hyvä-themed store.
4. Verify: each color swatch shows a `(N)` count below the color box.

---

**Scenario 2 — Count is hidden when "Show amount of results" is disabled**

1. Disable **Show amount of results** on the same attribute.
2. Run `bin/magento cache:clean`.
3. Open the same category page.
4. Verify: no count appears on any swatch option.

---

**Scenario 3 — Luma theme is unaffected**

1. Switch to a Luma/blank-theme store view with the same filter template (counts enabled).
2. Open the category page.
3. Verify: counts still render correctly — no regression.

---